### PR TITLE
Fixed Dockerfile and added documentation for the Docker usage

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ jobs:
     # Optional: Add basic test to verify the image works
     - name: Test Docker image
       run: |
-        docker run -v $PWD/birdnet_analyzer/example:/audio birdnet:local-test -m birdnet_analyzer.analyze --i /audio --o /audio --slist /audio
+        docker run -v $PWD/birdnet_analyzer/example:/input -v $PWD/birdnet_analyzer/example:/output birdnet:local-test -m birdnet_analyzer.analyze --i /input --o /output --slist /input
         
         # Verify output file content
         expected_header="Selection	View	Channel	Begin Time (s)	End Time (s)	Low Freq (Hz)	High Freq (Hz)	Common Name	Species Code	Confidence	Begin Path	File Offset (s)"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,23 +26,65 @@ jobs:
     # Optional: Add basic test to verify the image works
     - name: Test Docker image
       run: |
-        docker run -v $PWD/birdnet_analyzer/example:/input -v $PWD/birdnet_analyzer/example:/output birdnet:local-test -m birdnet_analyzer.analyze -i /input -o /output --slist /input
-        
-        # Verify output file content
-        expected_header="Selection	View	Channel	Begin Time (s)	End Time (s)	Low Freq (Hz)	High Freq (Hz)	Common Name	Species Code	Confidence	Begin Path	File Offset (s)"
-        expected_first_line="1	Spectrogram 1	1	0	3.0	0	15000	Black-capped Chickadee	bkcchi	0.8141	/audio/soundscape.wav	0"
-        
-        actual_header=$(head -n 1 birdnet_analyzer/example/soundscape.BirdNET.selection.table.txt)
-        actual_first_line=$(head -n 2 birdnet_analyzer/example/soundscape.BirdNET.selection.table.txt | tail -n 1)
-        
-        if [ "$actual_header" != "$expected_header" ] || [ "$actual_first_line" != "$expected_first_line" ]
-        then
-            echo "Output file content does not match expected content"
-            echo "Expected header: $expected_header"
-            echo "Actual header: $actual_header"
-            echo "Expected first line: $expected_first_line"
-            echo "Actual first line: $actual_first_line"
-            exit 1
-        else
+        docker run -v "$PWD/birdnet_analyzer/example:/input" -v "$PWD/birdnet_analyzer/example:/output" birdnet:local-test -m birdnet_analyzer.analyze -o /output --slist /input .
+
+        actual_file="$PWD/birdnet_analyzer/example/soundscapewav.BirdNET.selection.table.txt"
+
+        # Define expected values as arrays
+        expected_header_columns=("Selection" "View" "Channel" "Begin Time (s)" "End Time (s)" "Low Freq (Hz)" "High Freq (Hz)" "Common Name" "Species Code" "Confidence" "Begin Path" "File Offset (s)")
+        expected_first_row_columns=("1" "Spectrogram 1" "1" "0.0" "3.0" "0" "15000" "Black-capped Chickadee" "bkcchi" "0.8141" "./soundscape.wav" "0.0")
+
+        # Read actual values into arrays
+        IFS=$'\t' read -r -a actual_header_columns < <(head -n 1 "$actual_file")
+        IFS=$'\t' read -r -a actual_first_row_columns < <(head -n 2 "$actual_file" | tail -n 1)
+
+        # Trim whitespace from each value
+        trim_array() {
+            local arr_name=$1
+            local length=$(eval "echo \${#${arr_name}[@]}")
+            for ((i=0; i<length; i++)); do
+                eval "${arr_name}[$i]=\$(echo \${${arr_name}[$i]} | xargs)"
+            done
+        }
+
+        trim_array actual_header_columns
+        trim_array actual_first_row_columns
+
+
+        # Compare two arrays
+        compare_arrays() {
+            local label=$1
+            shift
+            local -a actual=("${!1}")
+            local -a expected=("${!2}")
+
+            if [ "${#actual[@]}" -ne "${#expected[@]}" ]; then
+                echo "$label column count mismatch: ${#actual[@]} vs ${#expected[@]}"
+                return 1
+            fi
+
+            local mismatch=0
+            for i in "${!expected[@]}"; do
+                if [ "${actual[$i]}" != "${expected[$i]}" ]; then
+                    echo "$label mismatch at column $((i+1)):"
+                    echo "  Expected: '${expected[$i]}'"
+                    echo "  Actual:   '${actual[$i]}'"
+                    mismatch=1
+                fi
+            done
+
+            return $mismatch
+        }
+
+        # Compare headers and first row
+        compare_arrays "Header" actual_header_columns[@] expected_header_columns[@]
+        header_ok=$?
+
+        compare_arrays "First data row" actual_first_row_columns[@] expected_first_row_columns[@]
+        first_row_ok=$?
+
+        if [ $header_ok -eq 0 ] && [ $first_row_ok -eq 0 ]; then
             echo "test received expected output file contents"
+        else
+            exit 1
         fi

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ jobs:
     # Optional: Add basic test to verify the image works
     - name: Test Docker image
       run: |
-        docker run -v $PWD/birdnet_analyzer/example:/input -v $PWD/birdnet_analyzer/example:/output birdnet:local-test -m birdnet_analyzer.analyze --i /input --o /output --slist /input
+        docker run -v $PWD/birdnet_analyzer/example:/input -v $PWD/birdnet_analyzer/example:/output birdnet:local-test -m birdnet_analyzer.analyze -i /input -o /output --slist /input
         
         # Verify output file content
         expected_header="Selection	View	Channel	Begin Time (s)	End Time (s)	Low Freq (Hz)	High Freq (Hz)	Common Name	Species Code	Confidence	Begin Path	File Offset (s)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
 # Build from Python slim
 FROM python:3.11
 
+# By default installing all dependencies, but this can be changed with build-arg
+ARG TARGET='all'
+
 # Install required packages while keeping the image small
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
 
 # Import all scripts
 COPY . ./
 
 # Install required Python packages
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir .[${TARGET}]
+
+WORKDIR /input
 
 # Add entry point to run the script
-ENTRYPOINT [ "python3" ]
-CMD [ "-m", "birdnet_analyzer.analyze" ]
+ENTRYPOINT [ "python3" , "-m", "birdnet_analyzer.analyze", "-o", "/output"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN pip3 install --no-cache-dir .[${TARGET}]
 WORKDIR /input
 
 # Add entry point to run the script
-ENTRYPOINT [ "python3" , "-m", "birdnet_analyzer.analyze", "-o", "/output"]
+ENTRYPOINT [ "python3" ]

--- a/docs/usage/docker.rst
+++ b/docs/usage/docker.rst
@@ -1,4 +1,53 @@
-Docker
-======
+Running in Docker    
+=================
 
-We are currently re-working our Docker setup. Please check back later for updates.
+BirdNET-Analyzer supports running CLI tools within a Docker containerized environment. To get started, follow these steps:
+
+**Step 1: Clone the Repository**
+
+Begin by cloning the official BirdNET-Analyzer repository:
+
+.. code:: bash
+    
+    git clone https://github.com/birdnet-team/BirdNET-Analyzer.git
+    cd BirdNET-Analyzer
+
+
+**Step 2: Install Docker**
+
+Ensure that Docker is installed and the Docker daemon is running on your machine. For more information on that, please consult the official `Docker documentation <https://docs.docker.com>`_.
+
+
+**Step 3: Build the Docker Image**
+
+You need to build the Docker image using the provided `Dockerfile`. The build can be customized based on the needs of your project. Multiple build targets are supported, and for more details, check the `pyproject.toml` file.
+
+By default, Docker will build an image containing all the necessary dependencies for all targets. If you require a specific target, set the build argument `TARGET` to the desired value. For example, if you want to build Docker container with dependencies for the training component, use the following command:
+
+.. code:: bash
+
+    docker build -t birdnet --build-arg TARGET=train .
+
+
+**Step 4: Run the Docker Image**
+
+Once the image is built, it will appear in your list of Docker images. To run the container, use the following command (assuming your image is named `birdnet`):
+
+.. code:: bash
+
+    docker run birdnet:latest
+
+.. note::
+
+    To ensure the software functions correctly, you need to attach two directories: one for input files and one for output files. The Docker image will use the `/input` directory for input files (which serves as the working directory inside the container) and the `/output` directory for output files. Use volume mapping to map these directories to your local directories.
+
+    .. code:: bash
+
+        #Assuming I have ~/my_input_folder with owls.wav file and I want to output results to ~/my_output_folder
+        
+        docker run \
+        -v ~/my_input_folder:/input \ # attaching input directory
+        -v ~/my_output_folder:/output \ # attaching output directory
+        birdnet:latest owls.wav # refering the file in the input directory
+
+By default, the Docker container’s entry point will execute the `python3 -m birdnet.analyzer` module. You can pass additional arguments directly via the Docker `run` command interface as needed.

--- a/docs/usage/docker.rst
+++ b/docs/usage/docker.rst
@@ -48,6 +48,6 @@ Once the image is built, it will appear in your list of Docker images. To run th
         docker run \
         -v ~/my_input_folder:/input \ # attaching input directory
         -v ~/my_output_folder:/output \ # attaching output directory
-        birdnet:latest owls.wav # refering the file in the input directory
+        birdnet:latest -m birdnet_analyzer.analyze -o /output owls.wav # refering the file in the input directory
 
-By default, the Docker container’s entry point will execute the `python3 -m birdnet.analyzer` module. You can pass additional arguments directly via the Docker `run` command interface as needed.
+Docker container’s entry point is `python3`. You need to add `-m birdnet_analyzer.{module-name}` with the name of the module to start. You can pass additional arguments directly via the Docker `run` command interface as needed.


### PR DESCRIPTION
I have fixed the Dockerfile. Apparently it fixes #602 . Also added documentation for usage of BirdNET-Analyzer in Docker. For now, Dockerfile will install the module and will switch to /input directory. User has to mount 2 directories: 1) His directory with input files to /input, 2) A directory where analyzer will output results to /output. Documentation describes it and gives an example.

Regarding the build I added TARGET argument, that is referenced as a target for additional dependency setup. By default it is set to `all`. User can define it via --build-arg argument while building the image.