### PR TITLE
Fix incorrect behavior in merge_consecutive_detections with max_consecutive limit

### DIFF
--- a/birdnet_analyzer/analyze/utils.py
+++ b/birdnet_analyzer/analyze/utils.py
@@ -429,7 +429,6 @@ def merge_consecutive_detections(results: dict[str, list], max_consecutive: int 
     Returns:
         The dictionary with merged detections.
     """
-    
     # If max_consecutive is 0 or 1, return original results
     if max_consecutive is not None and max_consecutive <= 1:
         return results
@@ -441,11 +440,9 @@ def merge_consecutive_detections(results: dict[str, list], max_consecutive: int 
             if label not in species:
                 species[label] = []
             species[label].append((timestamp, score))
-            
     # Sort timestamps by start time for each species
     for label, timestamps in species.items():
         species[label] = sorted(timestamps, key=lambda t: float(t[0].split("-", 1)[0]))
-        
     # Merge consecutive detections
     merged_results = {}
     for label in species:
@@ -463,7 +460,7 @@ def merge_consecutive_detections(results: dict[str, list], max_consecutive: int 
                 timestamps.pop(i)
                 
                 while i < len(timestamps) - 1 and float(next_end) >= float(timestamps[i + 1][0].split("-", 1)[0]):
-                    if max_consecutive and len(merged_scores) >= max_consecutive - 1:
+                    if max_consecutive and len(merged_scores) >= max_consecutive:
                         break
                     merged_scores.append(timestamps[i + 1][1])
                     next_end = timestamps[i + 1][0].split("-", 1)[1]

--- a/birdnet_analyzer/analyze/utils.py
+++ b/birdnet_analyzer/analyze/utils.py
@@ -429,6 +429,7 @@ def merge_consecutive_detections(results: dict[str, list], max_consecutive: int 
     Returns:
         The dictionary with merged detections.
     """
+
     # If max_consecutive is 0 or 1, return original results
     if max_consecutive is not None and max_consecutive <= 1:
         return results
@@ -440,9 +441,11 @@ def merge_consecutive_detections(results: dict[str, list], max_consecutive: int 
             if label not in species:
                 species[label] = []
             species[label].append((timestamp, score))
+
     # Sort timestamps by start time for each species
     for label, timestamps in species.items():
         species[label] = sorted(timestamps, key=lambda t: float(t[0].split("-", 1)[0]))
+        
     # Merge consecutive detections
     merged_results = {}
     for label in species:


### PR DESCRIPTION
The merge_consecutive_detections function was not correctly honoring the max_consecutive parameter. When max_consecutive=3 and three consecutive overlapping segments were present, the function only merged the first two, leaving the third out. This happened because the check:
```

if max_consecutive and len(merged_scores) >= max_consecutive - 1:
    break


```
stopped the loop before the last detection could be included, resulting in an incomplete merge.

The logic was updated to properly limit the number of merged detections:

The condition now correctly checks if the number of merged scores has reached the max_consecutive threshold before adding a new one, instead of one step too early.

Adjusted loop logic to ensure the third detection (and up to the limit) is included before stopping.

Changes can be tested with the following script. I am not including pytest file, since there is no pytest configured for this project, but you can create a file in the root of the project and start it with `python -m pytest test_file.py` (assuming pytest is installed).


```
import pytest

from birdnet_analyzer.analyze.utils import merge_consecutive_detections  # Adjust this import

@pytest.mark.parametrize("input_data,max_consecutive,expected", [
    # Test 1: No merging (max_consecutive = 1)
    (
        {
            "0-1": [("sparrow", 0.9)],
            "1-2": [("sparrow", 0.8)],
            "2-3": [("sparrow", 0.85)],
        },
        1,
        {
            "0-1": [("sparrow", 0.9)],
            "1-2": [("sparrow", 0.8)],
            "2-3": [("sparrow", 0.85)],
        },
    ),
    # Test 2: Merge all (max_consecutive = None)
    (
        {
            "0-1": [("sparrow", 0.9)],
            "1-2": [("sparrow", 0.8)],
            "2-3": [("sparrow", 0.85)],
        },
        None,
        {
            "0-3": [("sparrow", (0.9 + 0.85 + 0.8)/3)],
        },
    ),
    # Test 3: max_consecutive = 2, should merge first two only
    (
        {
            "0-1": [("sparrow", 0.9)],
            "1-2": [("sparrow", 0.8)],
            "2-3": [("sparrow", 0.85)],
        },
        2,
        {
            "0-2": [("sparrow", (0.9 + 0.8)/2)],
            "2-3": [("sparrow", 0.85)],
        },
    ),
    # Test 4: max_consecutive = 3, should merge all
    (
        {
            "0-1": [("sparrow", 0.9)],
            "1-2": [("sparrow", 0.8)],
            "2-3": [("sparrow", 0.85)],
        },
        3,
        {
            "0-3": [("sparrow", (0.9 + 0.85 + 0.8)/3)],
        },
    ),
    # Test 5: Two different species
    (
        {
            "0-1": [("sparrow", 0.9)],
            "1-2": [("robin", 0.7)],
            "2-3": [("sparrow", 0.85)],
        },
        None,
        {
            "0-1": [("sparrow", 0.9)],
            "1-2": [("robin", 0.7)],
            "2-3": [("sparrow", 0.85)],
        },
    ),
    # Test 6: Overlapping segments with same species
    (
        {
            "0-2": [("owl", 0.6)],
            "1.5-3": [("owl", 0.7)],
            "2.5-4": [("owl", 0.8)],
        },
        None,
        {
            "0-4": [("owl", (0.8 + 0.7 + 0.6)/3)],
        },
    ),
])
def test_merge_consecutive_detections(input_data, max_consecutive, expected):
    result = merge_consecutive_detections(input_data, max_consecutive)

    # Normalize result for easier comparison (sort labels inside each timestamp)
    normalized = {
        k: sorted(v) for k, v in sorted(result.items())
    }
    expected_normalized = {
        k: sorted(v) for k, v in sorted(expected.items())
    }

    assert normalized == expected_normalized

```
