### PR TITLE
Add link to Zenodo for model download

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can access documentation for this project [here](https://birdnet-team.github
 ## Download
 
 You can download installers for Windows and macOS from the [releases page](https://github.com/birdnet-team/BirdNET-Analyzer/releases/latest).
+Models can be found on [Zenodo](https://zenodo.org/records/15050749).
 
 ## About
 


### PR DESCRIPTION
As the models are no longer on Github, there should be a link to their new home.