### PR TITLE
Fix const reassignment error in version update checker

### DIFF
--- a/birdnet_analyzer/gui/assets/gui.js
+++ b/birdnet_analyzer/gui/assets/gui.js
@@ -29,11 +29,7 @@ function init() {
                 .then(response => {
                     const current_version = document.getElementById("current-version").textContent;
                     const response_object = JSON.parse(response);
-                    let latest_version = response_object.tag_name;
-
-                    if (latest_version.startsWith("v")) {
-                        latest_version = latest_version.slice(1);
-                    }
+                    const latest_version = response_object.tag_name.replace(/^v/, '');
 
                     if (current_version !== latest_version) {
                         const updateNotification = document.getElementById("update-available");

--- a/birdnet_analyzer/gui/assets/gui.js
+++ b/birdnet_analyzer/gui/assets/gui.js
@@ -29,7 +29,7 @@ function init() {
                 .then(response => {
                     const current_version = document.getElementById("current-version").textContent;
                     const response_object = JSON.parse(response);
-                    const latest_version = response_object.tag_name;
+                    let latest_version = response_object.tag_name;
 
                     if (latest_version.startsWith("v")) {
                         latest_version = latest_version.slice(1);


### PR DESCRIPTION
## PR Summary
This small PR fixes a JavaScript runtime where it attempts to reassign a constant variable in the version update check. The error occurred when trying to remove the 'v' prefix from GitHub release tags, which prevented the update notification from working correctly. By changing `const` to `let` for the `latest_version` variable, we allow proper version comparison while maintaining all existing functionality. We could also just do:
```javascript
const latest_version = response_object.tag_name.replace(/^v/, '');
```
let me know which one you prefer. 