### PR TITLE
Fix custom classifier false positives by removing BatchNormalization layers

### DIFF
--- a/birdnet_analyzer/model.py
+++ b/birdnet_analyzer/model.py
@@ -635,9 +635,6 @@ def build_linear_classifier(num_labels, input_size, hidden_units=0, dropout=0.0)
     # Input layer
     model.add(keras.layers.InputLayer(input_shape=(input_size,)))
 
-    # Batch normalization on input to standardize embeddings
-    model.add(keras.layers.BatchNormalization())
-
     # Optional L2 regularization for all dense layers
     regularizer = keras.regularizers.l2(1e-5)
 
@@ -649,9 +646,6 @@ def build_linear_classifier(num_labels, input_size, hidden_units=0, dropout=0.0)
 
         # Add a hidden layer with L2 regularization
         model.add(keras.layers.Dense(hidden_units, activation="relu", kernel_regularizer=regularizer, kernel_initializer="he_normal"))
-
-        # Add another batch normalization after the hidden layer
-        model.add(keras.layers.BatchNormalization())
 
     # Dropout layer before output
     if dropout > 0:


### PR DESCRIPTION
Custom classifiers trained with BirdNET-Analyzer v2.0.0+ produce excessive false positives with ~100% confidence scores on background noise, making them unusable for production. This issue was reported in #823 and #791.

## Root Cause

The issue is caused by a **train-inference mismatch** introduced in commit 5f6b5b0 ("Improve custom classifier training" #654):

**During Training:**
```
Embeddings → L2 normalize → BatchNorm (learns statistics) → Dense layers
```

**During Inference:**
```
Embeddings → NO normalization → BatchNorm (applies learned statistics) → Dense layers
```

BatchNormalization layers were added to the model architecture, and embeddings were L2-normalized during training. However, during inference, embeddings are fed to the model **without normalization**. This mismatch causes BatchNorm to receive completely different input distributions, breaking the learned decision boundaries.

## Solution

This PR removes both BatchNormalization layers from `build_linear_classifier()`:
- Line 639: After input layer
- Line 654: After hidden layer

This restores the reliable v1.5.1 architecture while preserving other v2.x improvements:
- L2 regularization
- Improved learning rate schedule
- Better optimizer configuration
- Enhanced evaluation metrics

## Note on Recent Changes

Commit 804b097 removed L2 normalization during training, which helps but doesn't fully resolve the issue. BatchNorm can still cause problems due to:
- Small batch sizes during inference
- Different data distributions between training and real-world use
- Mismatched statistics in saved models

Removing BatchNorm entirely is the most robust solution.

Fixes #823
Fixes #791
