### PR TITLE
Add tqdm progress bar option for CLI

### DIFF
--- a/birdnet_analyzer/analyze/core.py
+++ b/birdnet_analyzer/analyze/core.py
@@ -1,36 +1,6 @@
 import os
 from tqdm import tqdm
 from typing import Literal
-import multiprocessing as mp
-import threading
-import functools
-
-
-def queue_listener(q):
-    """Listens for messages on the queue and prints them using tqdm.write or print."""
-    import birdnet_analyzer.config as cfg
-
-    while True:
-        try:
-            message = q.get()
-            if message is None:  # Sentinel value to stop the thread
-                break
-            if cfg.SHOW_PROGRESS:
-                tqdm.write(message)
-            else:
-                print(message, flush=True)
-        except Exception as e:
-            if cfg.SHOW_PROGRESS:
-                tqdm.write(f"Listener error: {e}")
-            else:
-                print(f"Listener error: {e}", flush=True)
-            break
-
-
-def worker_wrapper(output_queue, item):
-    from birdnet_analyzer.analyze.utils import analyze_file
-
-    return analyze_file(item, output_queue)
 
 
 def analyze(
@@ -49,6 +19,7 @@ def analyze(
     fmax: int = 15000,
     audio_speed: float = 1.0,
     batch_size: int = 1,
+    show_progress: bool = True,
     combine_results: bool = False,
     rtype: Literal["table", "audacity", "kaleidoscope", "csv"] | list[Literal["table", "audacity", "kaleidoscope", "csv"]] = "table",
     skip_existing_results: bool = False,
@@ -59,7 +30,6 @@ def analyze(
     locale: str = "en",
     additional_columns: list[str] | None = None,
     use_perch: bool = False,
-    show_progress: bool = True,
 ):
     """
     Analyzes audio files for bird species detection using the BirdNET-Analyzer.
@@ -145,28 +115,16 @@ def analyze(
     # Analyze files
     if cfg.CPU_THREADS < 2 or len(flist) < 2:
         if cfg.SHOW_PROGRESS:
-            result_files.extend(tqdm.tqdm((analyze_file(f) for f in flist), total=len(flist)))
+            result_files.extend(tqdm((analyze_file(f) for f in flist), total=len(flist)))
         else:
             result_files.extend(analyze_file(f) for f in flist)
     else:
-        # Set up multiprocessing with queue for messages
-        manager = mp.Manager()
-        output_queue = manager.Queue()
-        listener_thread = threading.Thread(target=queue_listener, args=(output_queue,))
-        listener_thread.start()
-
-        worker = functools.partial(worker_wrapper, output_queue)
-
         with Pool(cfg.CPU_THREADS) as p:
-            # Map analyze_file function to each entry in flist
+            # Map analyzeFile function to each entry in flist
             if cfg.SHOW_PROGRESS:
-                result_files = list(tqdm(p.imap(worker, flist), total=len(flist)))
+                result_files = list(tqdm(p.imap(analyze_file, flist), total=len(flist)))
             else:
-                result_files = list(p.imap(worker, flist))
-
-        # Stop the listener thread
-        output_queue.put(None)
-        listener_thread.join()
+                result_files = list(p.imap(analyze_file, flist))
 
     # Combine results?
     if cfg.COMBINE_RESULTS:

--- a/birdnet_analyzer/analyze/core.py
+++ b/birdnet_analyzer/analyze/core.py
@@ -20,7 +20,7 @@ def analyze(
     fmax: int = 15000,
     audio_speed: float = 1.0,
     batch_size: int = 1,
-    show_progress: bool = True,
+    show_progress: bool = False,
     combine_results: bool = False,
     rtype: Literal["table", "audacity", "kaleidoscope", "csv"] | list[Literal["table", "audacity", "kaleidoscope", "csv"]] = "table",
     skip_existing_results: bool = False,

--- a/birdnet_analyzer/analyze/core.py
+++ b/birdnet_analyzer/analyze/core.py
@@ -1,6 +1,7 @@
 import os
-from tqdm import tqdm
 from typing import Literal
+
+from tqdm import tqdm
 
 
 def analyze(

--- a/birdnet_analyzer/analyze/core.py
+++ b/birdnet_analyzer/analyze/core.py
@@ -114,7 +114,7 @@ def analyze(
 
     # Analyze files
     if cfg.CPU_THREADS < 2 or len(flist) < 2:
-        result_files.extend(tqdm(analyze_file(f) for f in flist, total=len(flist), desc="Processing audio files...", disable=not cfg.SHOW_PROGRESS))
+        result_files.extend(tqdm((analyze_file(f) for f in flist), total=len(flist), desc="Processing audio files...", disable=not cfg.SHOW_PROGRESS))
     else:
         with Pool(cfg.CPU_THREADS) as p:
             # Map analyzeFile function to each entry in flist

--- a/birdnet_analyzer/analyze/core.py
+++ b/birdnet_analyzer/analyze/core.py
@@ -1,5 +1,36 @@
 import os
+from tqdm import tqdm
 from typing import Literal
+import multiprocessing as mp
+import threading
+import functools
+
+
+def queue_listener(q):
+    """Listens for messages on the queue and prints them using tqdm.write or print."""
+    import birdnet_analyzer.config as cfg
+
+    while True:
+        try:
+            message = q.get()
+            if message is None:  # Sentinel value to stop the thread
+                break
+            if cfg.SHOW_PROGRESS:
+                tqdm.write(message)
+            else:
+                print(message, flush=True)
+        except Exception as e:
+            if cfg.SHOW_PROGRESS:
+                tqdm.write(f"Listener error: {e}")
+            else:
+                print(f"Listener error: {e}", flush=True)
+            break
+
+
+def worker_wrapper(output_queue, item):
+    from birdnet_analyzer.analyze.utils import analyze_file
+
+    return analyze_file(item, output_queue)
 
 
 def analyze(
@@ -28,6 +59,7 @@ def analyze(
     locale: str = "en",
     additional_columns: list[str] | None = None,
     use_perch: bool = False,
+    show_progress: bool = True,
 ):
     """
     Analyzes audio files for bird species detection using the BirdNET-Analyzer.
@@ -98,6 +130,7 @@ def analyze(
         labels_file=cfg.LABELS_FILE,
         additional_columns=additional_columns,
         use_perch=use_perch,
+        show_progress=show_progress,
     )
 
     print(f"Found {len(cfg.FILE_LIST)} files to analyze")
@@ -111,14 +144,29 @@ def analyze(
 
     # Analyze files
     if cfg.CPU_THREADS < 2 or len(flist) < 2:
-        result_files.extend(analyze_file(f) for f in flist)
+        if cfg.SHOW_PROGRESS:
+            result_files.extend(tqdm.tqdm((analyze_file(f) for f in flist), total=len(flist)))
+        else:
+            result_files.extend(analyze_file(f) for f in flist)
     else:
+        # Set up multiprocessing with queue for messages
+        manager = mp.Manager()
+        output_queue = manager.Queue()
+        listener_thread = threading.Thread(target=queue_listener, args=(output_queue,))
+        listener_thread.start()
+
+        worker = functools.partial(worker_wrapper, output_queue)
+
         with Pool(cfg.CPU_THREADS) as p:
-            # Map analyzeFile function to each entry in flist
-            results = p.map_async(analyze_file, flist)
-            # Wait for all tasks to complete
-            results.wait()
-            result_files = results.get()
+            # Map analyze_file function to each entry in flist
+            if cfg.SHOW_PROGRESS:
+                result_files = list(tqdm(p.imap(worker, flist), total=len(flist)))
+            else:
+                result_files = list(p.imap(worker, flist))
+
+        # Stop the listener thread
+        output_queue.put(None)
+        listener_thread.join()
 
     # Combine results?
     if cfg.COMBINE_RESULTS:
@@ -155,6 +203,7 @@ def _set_params(
     labels_file=None,
     additional_columns=None,
     use_perch=False,
+    show_progress=True,
 ):
     import birdnet_analyzer.config as cfg
     from birdnet_analyzer.analyze.utils import load_codes
@@ -201,6 +250,7 @@ def _set_params(
     cfg.BATCH_SIZE = bs
     cfg.ADDITIONAL_COLUMNS = additional_columns
     cfg.USE_PERCH = use_perch
+    cfg.SHOW_PROGRESS = show_progress
 
     if cfg.USE_PERCH and custom_classifier:
         raise ValueError("Selected custom classifier and Perch model, please select only one.")

--- a/birdnet_analyzer/analyze/core.py
+++ b/birdnet_analyzer/analyze/core.py
@@ -114,18 +114,11 @@ def analyze(
 
     # Analyze files
     if cfg.CPU_THREADS < 2 or len(flist) < 2:
-        if cfg.SHOW_PROGRESS:
-            result_files.extend(tqdm((analyze_file(f) for f in flist), total=len(flist)))
-        else:
-            result_files.extend(analyze_file(f) for f in flist)
+        result_files.extend(tqdm(analyze_file(f) for f in flist, total=len(flist), desc="Processing audio files...", disable=not cfg.SHOW_PROGRESS))
     else:
         with Pool(cfg.CPU_THREADS) as p:
             # Map analyzeFile function to each entry in flist
-            if cfg.SHOW_PROGRESS:
-                result_files = list(tqdm(p.imap(analyze_file, flist), total=len(flist)))
-            else:
-                result_files = list(p.imap(analyze_file, flist))
-
+            result_files = list(tqdm(p.imap(analyze_file, flist), total=len(flist), desc="Processing audio files...", disable=not cfg.SHOW_PROGRESS))
     # Combine results?
     if cfg.COMBINE_RESULTS:
         print(f"Combining results, writing to {cfg.OUTPUT_PATH}...", end="", flush=True)

--- a/birdnet_analyzer/analyze/utils.py
+++ b/birdnet_analyzer/analyze/utils.py
@@ -5,10 +5,8 @@ import json
 import operator
 import os
 from collections.abc import Sequence
-from multiprocessing import Queue
 
 import numpy as np
-from tqdm import tqdm
 
 import birdnet_analyzer.config as cfg
 from birdnet_analyzer import audio, model, utils
@@ -650,13 +648,12 @@ def get_result_file_names(fpath: str):
     return result_names
 
 
-def analyze_file(item, queue: Queue = None) -> dict[str, str] | None:
+def analyze_file(item) -> dict[str, str] | None:
     """
     Analyzes an audio file and generates prediction results.
 
     Args:
         item (tuple): A tuple containing the file path (str) and configuration settings.
-        queue (Queue, optional): A multiprocessing queue for sending messages. Defaults to None.
 
     Returns:
         dict or None: A dictionary of result file names if analysis is successful,

--- a/birdnet_analyzer/analyze/utils.py
+++ b/birdnet_analyzer/analyze/utils.py
@@ -5,8 +5,10 @@ import json
 import operator
 import os
 from collections.abc import Sequence
+from multiprocessing import Queue
 
 import numpy as np
+from tqdm import tqdm
 
 import birdnet_analyzer.config as cfg
 from birdnet_analyzer import audio, model, utils
@@ -648,12 +650,13 @@ def get_result_file_names(fpath: str):
     return result_names
 
 
-def analyze_file(item) -> dict[str, str] | None:
+def analyze_file(item, queue: Queue = None) -> dict[str, str] | None:
     """
     Analyzes an audio file and generates prediction results.
 
     Args:
         item (tuple): A tuple containing the file path (str) and configuration settings.
+        queue (Queue, optional): A multiprocessing queue for sending messages. Defaults to None.
 
     Returns:
         dict or None: A dictionary of result file names if analysis is successful,
@@ -668,7 +671,11 @@ def analyze_file(item) -> dict[str, str] | None:
     result_file_names = get_result_file_names(fpath)
 
     if cfg.SKIP_EXISTING_RESULTS and all(os.path.exists(f) for f in result_file_names.values()):
-        print(f"Skipping {fpath} as it has already been analyzed", flush=True)
+        message = f"Skipping {fpath} as it has already been analyzed"
+        if queue:
+            queue.put(message)
+        else:
+            print(message, flush=True)
         return None  # or return path to combine later? TODO
 
     # Start time
@@ -676,7 +683,14 @@ def analyze_file(item) -> dict[str, str] | None:
     results = {}
 
     # Status
-    print(f"Analyzing {fpath}", flush=True)
+    message = f"Analyzing {fpath}"
+    if queue:
+        queue.put(message)
+    else:
+        if cfg.SHOW_PROGRESS:
+            tqdm.write(message)
+        else:
+            print(message, flush=True)
 
     # Process each chunk
     try:
@@ -701,7 +715,14 @@ def analyze_file(item) -> dict[str, str] | None:
 
     except Exception as ex:
         # Write error log
-        print(f"Error: Cannot analyze audio file {fpath}.\n", flush=True)
+        message = f"Error: Cannot analyze audio file {fpath}.\n"
+        if queue:
+            queue.put(message)
+        else:
+            if cfg.SHOW_PROGRESS:
+                tqdm.write(message)
+            else:
+                print(message, flush=True)
         utils.write_error_log(ex)
         msg = str(ex)
 
@@ -713,12 +734,26 @@ def analyze_file(item) -> dict[str, str] | None:
 
     except Exception as ex:
         # Write error log
-        print(f"Error: Cannot save result for {fpath}.\n", flush=True)
+        message = f"Error: Cannot save result for {fpath}.\n"
+        if queue:
+            queue.put(message)
+        else:
+            if cfg.SHOW_PROGRESS:
+                tqdm.write(message)
+            else:
+                print(message, flush=True)
         utils.write_error_log(ex)
 
         return str(ex)
 
     delta_time = (datetime.datetime.now() - start_time).total_seconds()
-    print(f"Finished {fpath} in {delta_time:.2f} seconds", flush=True)
+    message = f"Finished {fpath} in {delta_time:.2f} seconds"
+    if queue:
+        queue.put(message)
+    else:
+        if cfg.SHOW_PROGRESS:
+            tqdm.write(message)
+        else:
+            print(message, flush=True)
 
     return result_file_names

--- a/birdnet_analyzer/analyze/utils.py
+++ b/birdnet_analyzer/analyze/utils.py
@@ -200,7 +200,7 @@ def generate_csv(timestamps: list[str], result: dict[str, list], afile_path: str
 
     Args:
         timestamps (list[str]): A list of timestamp strings in the format "start-end".
-        result (dict[str, list]): A dictionary where keys are timestamp strings and values are lists of tuples.
+        result (dict[str, list): A dictionary where keys are timestamp strings and values are lists of tuples.
                                   Each tuple contains a label and a confidence score.
         afile_path (str): The file path of the audio file being analyzed.
         result_path (str): The file path where the resulting CSV file will be saved.
@@ -672,9 +672,7 @@ def analyze_file(item, queue: Queue = None) -> dict[str, str] | None:
 
     if cfg.SKIP_EXISTING_RESULTS and all(os.path.exists(f) for f in result_file_names.values()):
         message = f"Skipping {fpath} as it has already been analyzed"
-        if queue:
-            queue.put(message)
-        else:
+        if not cfg.SHOW_PROGRESS:
             print(message, flush=True)
         return None  # or return path to combine later? TODO
 
@@ -684,13 +682,8 @@ def analyze_file(item, queue: Queue = None) -> dict[str, str] | None:
 
     # Status
     message = f"Analyzing {fpath}"
-    if queue:
-        queue.put(message)
-    else:
-        if cfg.SHOW_PROGRESS:
-            tqdm.write(message)
-        else:
-            print(message, flush=True)
+    if not cfg.SHOW_PROGRESS:
+        print(message, flush=True)
 
     # Process each chunk
     try:
@@ -716,13 +709,8 @@ def analyze_file(item, queue: Queue = None) -> dict[str, str] | None:
     except Exception as ex:
         # Write error log
         message = f"Error: Cannot analyze audio file {fpath}.\n"
-        if queue:
-            queue.put(message)
-        else:
-            if cfg.SHOW_PROGRESS:
-                tqdm.write(message)
-            else:
-                print(message, flush=True)
+        if not cfg.SHOW_PROGRESS:
+            print(message, flush=True)
         utils.write_error_log(ex)
         msg = str(ex)
 
@@ -735,25 +723,15 @@ def analyze_file(item, queue: Queue = None) -> dict[str, str] | None:
     except Exception as ex:
         # Write error log
         message = f"Error: Cannot save result for {fpath}.\n"
-        if queue:
-            queue.put(message)
-        else:
-            if cfg.SHOW_PROGRESS:
-                tqdm.write(message)
-            else:
-                print(message, flush=True)
+        if not cfg.SHOW_PROGRESS:
+            print(message, flush=True)
         utils.write_error_log(ex)
 
         return str(ex)
 
     delta_time = (datetime.datetime.now() - start_time).total_seconds()
     message = f"Finished {fpath} in {delta_time:.2f} seconds"
-    if queue:
-        queue.put(message)
-    else:
-        if cfg.SHOW_PROGRESS:
-            tqdm.write(message)
-        else:
-            print(message, flush=True)
+    if not cfg.SHOW_PROGRESS:
+        print(message, flush=True)
 
     return result_file_names

--- a/birdnet_analyzer/analyze/utils.py
+++ b/birdnet_analyzer/analyze/utils.py
@@ -668,9 +668,8 @@ def analyze_file(item) -> dict[str, str] | None:
     result_file_names = get_result_file_names(fpath)
 
     if cfg.SKIP_EXISTING_RESULTS and all(os.path.exists(f) for f in result_file_names.values()):
-        message = f"Skipping {fpath} as it has already been analyzed"
         if not cfg.SHOW_PROGRESS:
-            print(message, flush=True)
+            print(f"Skipping {fpath} as it has already been analyzed", flush=True)
         return None  # or return path to combine later? TODO
 
     # Start time
@@ -678,9 +677,8 @@ def analyze_file(item) -> dict[str, str] | None:
     results = {}
 
     # Status
-    message = f"Analyzing {fpath}"
     if not cfg.SHOW_PROGRESS:
-        print(message, flush=True)
+        print(f"Analyzing {fpath}", flush=True)
 
     # Process each chunk
     try:
@@ -705,9 +703,8 @@ def analyze_file(item) -> dict[str, str] | None:
 
     except Exception as ex:
         # Write error log
-        message = f"Error: Cannot analyze audio file {fpath}.\n"
         if not cfg.SHOW_PROGRESS:
-            print(message, flush=True)
+            print(f"Error: Cannot analyze audio file {fpath}.\n", flush=True)
         utils.write_error_log(ex)
         msg = str(ex)
 
@@ -719,16 +716,14 @@ def analyze_file(item) -> dict[str, str] | None:
 
     except Exception as ex:
         # Write error log
-        message = f"Error: Cannot save result for {fpath}.\n"
         if not cfg.SHOW_PROGRESS:
-            print(message, flush=True)
+            print(f"Error: Cannot save result for {fpath}.\n", flush=True)
         utils.write_error_log(ex)
 
         return str(ex)
 
     delta_time = (datetime.datetime.now() - start_time).total_seconds()
-    message = f"Finished {fpath} in {delta_time:.2f} seconds"
     if not cfg.SHOW_PROGRESS:
-        print(message, flush=True)
+        print(f"Finished {fpath} in {delta_time:.2f} seconds", flush=True)
 
     return result_file_names

--- a/birdnet_analyzer/cli.py
+++ b/birdnet_analyzer/cli.py
@@ -400,6 +400,13 @@ def analyzer_parser():
 
     parser.add_argument("--use_perch", action="store_true", help="Use the Perch model for detection.")
 
+    parser.add_argument(
+        "--show_progress",
+        action="store_true",
+        default=False,
+        help="Show progress bar during analysis.",
+    )
+
     return parser
 
 

--- a/birdnet_analyzer/config.py
+++ b/birdnet_analyzer/config.py
@@ -141,6 +141,9 @@ ANALYSIS_PARAMS_FILENAME: str = "BirdNET_analysis_params.csv"
 SKIP_EXISTING_RESULTS: bool = False
 
 COMBINE_RESULTS: bool = False
+
+SHOW_PROGRESS: bool = False
+
 #####################
 # Training settings #
 #####################
@@ -263,6 +266,7 @@ def set_config(c: dict):
 #####################
 # Convenience funcs #
 #####################
+
 
 def perch_labels_file():
     return os.path.join(PERCH_V2_MODEL_PATH, "assets", "labels.csv")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "Stefan Kahl" }]
 maintainers = [{ name = "Josef Haupt" }, { name = "Max Mauermann" }]
 keywords = ["birdnet", "birdnet-analyzer"]
 readme = "README.md"
-requires-python = ">=3.11, <3.13"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "Stefan Kahl" }]
 maintainers = [{ name = "Josef Haupt" }, { name = "Max Mauermann" }]
 keywords = ["birdnet", "birdnet-analyzer"]
 readme = "README.md"
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "Stefan Kahl" }]
 maintainers = [{ name = "Josef Haupt" }, { name = "Max Mauermann" }]
 keywords = ["birdnet", "birdnet-analyzer"]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "Stefan Kahl" }]
 maintainers = [{ name = "Josef Haupt" }, { name = "Max Mauermann" }]
 keywords = ["birdnet", "birdnet-analyzer"]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11, <3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",

--- a/tests/analyze/test_analyze.py
+++ b/tests/analyze/test_analyze.py
@@ -110,7 +110,7 @@ def test_analyze_directory_multiprocess(mock_save_params: MagicMock, mock_pool, 
     # Verify behavior
     mock_set_params.assert_called_once()
     mock_pool.assert_called_once_with(2)
-    pool_instance.map_async.assert_called_once()
+    pool_instance.imap.assert_called_once()
     mock_save_params.assert_called_once()
 
 
@@ -263,6 +263,7 @@ def test_analyze_with_real_custom_classifier(setup_test_environment):
         for row in reader:
             assert row["Common Name"] in labels, f"Unexpected label found: {row['Common Name']}"
 
+
 def test_analyze_with_real_custom_classifier_and_species_list(setup_test_environment):
     """Test analyzing with a real custom classifier and species list."""
     env = setup_test_environment
@@ -286,6 +287,7 @@ def test_analyze_with_real_custom_classifier_and_species_list(setup_test_environ
         reader = csv.DictReader(f, delimiter="\t")
         for row in reader:
             assert row["Common Name"] in valid_species, f"Label not in species list: {row['Common Name']}"
+
 
 @patch("birdnet_analyzer.utils.ensure_model_exists")
 def test_analyze_with_negative_speed(setup_test_environment):
@@ -369,6 +371,7 @@ def test_analyze_with_too_high_overlap(setup_test_environment):
     # Call function under test
     with pytest.raises(ValueError, match=rf"Overlap must be less than or equal to {cfg.BIRDNET_SIG_LENGTH - 0.1} seconds for BirdNET model."):
         analyze(soundscape_path, env["output_dir"], audio_speed=1.0, top_n=1, overlap=3.0)
+
 
 @pytest.mark.skipif(platform.system() == "Darwin", reason="Don't ask me why it times out on macOS.")
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Description**
This PR improves the user experience when running file analysis by:

Wrapping the analyze_file multiprocessing pool with a tqdm progress bar when show_progress is True, providing real-time feedback on processing progress.
Suppressing standard output from worker processes when show_progress is enabled, resulting in a cleaner progress display.
No changes were made to the analysis logic or results.

**Motivation**
I decided to open this PR after running the analyzer on a directory with ~50,000 audio files and found the CLI output overwhelming and hard to follow. These changes make it easier to monitor progress and keep the output informative and manageable for large-scale analyses.