### PR TITLE
Quickfix: Pin Gradio <6.0 to fix GUI Audio TypeErrors (#862)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ train = ["keras-tuner"]
 server = ["bottle", "requests"]
 gui = [
     "birdnet-analyzer[train,embeddings]",
-    "gradio>=5.46",
+    "gradio>=5.46, <6.0",
     "pywebview>=6.0",
     "pyobjc-framework-UniformTypeIdentifiers;platform_system=='Darwin'", # macOS only, until pywebview adds it as dependency
     "plotly[express]",


### PR DESCRIPTION
## Quickfix: Pin Gradio <6.0 to fix GUI Audio TypeErrors (#862)

**Problem:** Gradio >=6.0 crashes GUI:
```TypeError: Audio.init() got unexpected keyword 'show_download_button'/'buttons'```

**See:**

https://github.com/birdnet-team/BirdNET-Analyzer/blob/a5a9e1dae52736c6811842ad23317004404d7870/birdnet_analyzer/gui/single_file.py#L127

**Fix:** Update `pyproject.toml`:
```diff
gui = [
  ...
- "gradio>=5.46",
+ "gradio>=5.46, <6.0",
  ...
]
```

**Test:** `pip install -e '.[gui]'` → GUI starts without errors.

**Future:** Gradio 6 migration needed. 

Fixes #862