### PR TITLE
Parquet output format

### DIFF
--- a/birdnet_analyzer/analyze/cli.py
+++ b/birdnet_analyzer/analyze/cli.py
@@ -21,7 +21,7 @@ def main():
     except Exception:
         pass
 
-    if "additional_columns" in args and args.additional_columns and "csv" not in args.rtype:
+    if "additional_columns" in args and args.additional_columns and ("csv" not in args.rtype or "parquet" not in args.rtype):
         import warnings
 
         warnings.warn("The --additional_columns argument is only valid for CSV output. It will be ignored.", stacklevel=1)

--- a/birdnet_analyzer/analyze/core.py
+++ b/birdnet_analyzer/analyze/core.py
@@ -22,7 +22,7 @@ def analyze(
     batch_size: int = 1,
     show_progress: bool = False,
     combine_results: bool = False,
-    rtype: Literal["table", "audacity", "kaleidoscope", "csv"] | list[Literal["table", "audacity", "kaleidoscope", "csv"]] = "table",
+    rtype: Literal["table", "audacity", "kaleidoscope", "csv", "parquet"] | list[Literal["table", "audacity", "kaleidoscope", "csv", "parquet"]] = "table",
     skip_existing_results: bool = False,
     sf_thresh: float = 0.03,
     top_n: int | None = None,
@@ -50,7 +50,7 @@ def analyze(
         audio_speed (float, optional): Speed factor for audio playback during analysis. Defaults to 1.0.
         batch_size (int, optional): Batch size for processing. Defaults to 1.
         combine_results (bool, optional): Whether to combine results into a single file. Defaults to False.
-        rtype (Literal["table", "audacity", "kaleidoscope", "csv"] | List[Literal["table", "audacity", "kaleidoscope", "csv"]], optional):
+        rtype (Literal["table", "audacity", "kaleidoscope", "csv", "parquet"] | List[Literal["table", "audacity", "kaleidoscope", "csv", "parquet"]], optional):
             Output format(s) for results. Defaults to "table".
         skip_existing_results (bool, optional): Whether to skip analysis for files with existing results. Defaults to False.
         sf_thresh (float, optional): Threshold for species filtering. Defaults to 0.03.

--- a/birdnet_analyzer/analyze/utils.py
+++ b/birdnet_analyzer/analyze/utils.py
@@ -272,8 +272,6 @@ def generate_parquet(timestamps: list[str], result: dict[str, list], afile_path:
         for extra_col_key, extra_col_value in extra_columns_map.items():
             table_vals[extra_col_key] = [str(extra_col_value) for _ in range(len(start_times))]
 
-        print(table_vals)
-
         table = pa.table(table_vals, schema=parquet_schema)
 
         writer.write_table(table)

--- a/birdnet_analyzer/analyze/utils.py
+++ b/birdnet_analyzer/analyze/utils.py
@@ -230,16 +230,15 @@ def generate_parquet(timestamps: list[str], result: dict[str, list], afile_path:
 
     writer = pq.ParquetWriter(result_path, parquet_schema)
 
-    for timestamp in timestamps:
-        # create a single table per timestamp
-        # larger tables allow for better compression, but larger tables mean more memory
-        start_times: list[float] = []
-        end_times: list[float] = []
-        scientific_names: list[str] = []
-        common_names: list[str] = []
-        scores: list[float] = []
-        files: list[str] = []
+    # create a single table per file
+    start_times: list[float] = []
+    end_times: list[float] = []
+    scientific_names: list[str] = []
+    common_names: list[str] = []
+    scores: list[float] = []
+    files: list[str] = []
 
+    for timestamp in timestamps:
         # taken from generate_csv function
         for raw_label, score in result[timestamp]:
             start, end = timestamp.split("-", 1)
@@ -259,23 +258,21 @@ def generate_parquet(timestamps: list[str], result: dict[str, list], afile_path:
             scores.append(score)
             files.append(afile_path)
 
-        # match the schema
-        table_vals = {
-            "start_s": start_times,
-            "end_s": end_times,
-            "scientific_name": scientific_names,
-            "common_name": common_names,
-            "confidence": scores,
-            "file": files,
-        }
+    # match the schema
+    table_vals = {
+        "start_s": start_times,
+        "end_s": end_times,
+        "scientific_name": scientific_names,
+        "common_name": common_names,
+        "confidence": scores,
+        "file": files,
+    }
+    # add extra cols, which are just repeated for all rows
+    for extra_col_key, extra_col_value in extra_columns_map.items():
+        table_vals[extra_col_key] = [str(extra_col_value) for _ in range(len(start_times))]
 
-        for extra_col_key, extra_col_value in extra_columns_map.items():
-            table_vals[extra_col_key] = [str(extra_col_value) for _ in range(len(start_times))]
-
-        table = pa.table(table_vals, schema=parquet_schema)
-
-        writer.write_table(table)
-
+    table = pa.table(table_vals, schema=parquet_schema)
+    writer.write_table(table)
     writer.close()
 
 

--- a/birdnet_analyzer/analyze/utils.py
+++ b/birdnet_analyzer/analyze/utils.py
@@ -7,6 +7,9 @@ import os
 from collections.abc import Sequence
 
 import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pyarrow import dataset as ds
 
 import birdnet_analyzer.config as cfg
 from birdnet_analyzer import audio, model, utils
@@ -187,6 +190,97 @@ def generate_kaleidoscope(timestamps: list[str], result: dict[str, list], afile_
     utils.save_result_file(result_path, out_string)
 
 
+def generate_parquet(timestamps: list[str], result: dict[str, list], afile_path: str, result_path: str):
+    """
+    Generates a Parquet file from the given timestamps and results.
+
+    Args:
+        timestamps (list[str]): A list of timestamp strings in the format "start-end".
+        result (dict[str, list): A dictionary where keys are timestamp strings and values are lists of tuples.
+                                  Each tuple contains a label and a confidence score.
+        afile_path (str): The file path of the audio file being analyzed.
+        result_path (str): The file path where the resulting parquet file will be saved.
+
+    Returns:
+        None
+    """
+    from birdnet_analyzer.analyze import POSSIBLE_ADDITIONAL_COLUMNS_MAP
+
+    # standard fields for output
+    fields = [
+        pa.field("start_s", pa.float32()),
+        pa.field("end_s", pa.float32()),
+        pa.field("scientific_name", pa.string()),
+        pa.field("common_name", pa.string()),
+        pa.field("confidence", pa.float32()),
+        pa.field("file", pa.string()),
+    ]
+
+    extra_columns_map = {}
+
+    if cfg.ADDITIONAL_COLUMNS:
+        for col in POSSIBLE_ADDITIONAL_COLUMNS_MAP:
+            if col in cfg.ADDITIONAL_COLUMNS:
+                extra_columns_map[col] = POSSIBLE_ADDITIONAL_COLUMNS_MAP[col]()
+                # TODO: get the correct dtype for the extra columns
+                fields.append(pa.field(col, pa.string()))
+
+    # define the parquet schema, including the extra columns
+    parquet_schema = pa.schema(fields)
+
+    writer = pq.ParquetWriter(result_path, parquet_schema)
+
+    for timestamp in timestamps:
+        # create a single table per timestamp
+        # larger tables allow for better compression, but larger tables mean more memory
+        start_times: list[float] = []
+        end_times: list[float] = []
+        scientific_names: list[str] = []
+        common_names: list[str] = []
+        scores: list[float] = []
+        files: list[str] = []
+
+        # taken from generate_csv function
+        for raw_label, score in result[timestamp]:
+            start, end = timestamp.split("-", 1)
+            label = cfg.TRANSLATED_LABELS[cfg.LABELS.index(raw_label)] if cfg.TRANSLATED_LABELS else raw_label
+
+            if cfg.USE_PERCH:
+                common = scientific = label
+            else:
+                split_label = label.split("_", 1)
+                scientific = split_label[0]
+                common = split_label[-1]
+
+            start_times.append(float(start))
+            end_times.append(float(end))
+            scientific_names.append(scientific)
+            common_names.append(common)
+            scores.append(score)
+            files.append(afile_path)
+
+        # match the schema
+        table_vals = {
+            "start_s": start_times,
+            "end_s": end_times,
+            "scientific_name": scientific_names,
+            "common_name": common_names,
+            "confidence": scores,
+            "file": files,
+        }
+
+        for extra_col_key, extra_col_value in extra_columns_map.items():
+            table_vals[extra_col_key] = [str(extra_col_value) for _ in range(len(start_times))]
+
+        print(table_vals)
+
+        table = pa.table(table_vals, schema=parquet_schema)
+
+        writer.write_table(table)
+
+    writer.close()
+
+
 def generate_csv(timestamps: list[str], result: dict[str, list], afile_path: str, result_path: str):
     """
     Generates a CSV file from the given timestamps and results.
@@ -275,6 +369,9 @@ def save_result_files(r: dict[str, list], result_files: dict[str, str], afile_pa
 
     if "csv" in cfg.RESULT_TYPES:
         generate_csv(timestamps, r_merged, afile_path, result_files["csv"])
+
+    if "parquet" in cfg.RESULT_TYPES:
+        generate_parquet(timestamps, r_merged, afile_path, result_files["parquet"])
 
 
 def combine_raven_tables(saved_results: list[str]):
@@ -405,6 +502,23 @@ def combine_csv_files(saved_results: list[str]):
         f.write(out_string)
 
 
+def combine_parquet_files(saved_results: list[str]):
+    """
+    Combines multiple parquet files into a single parquet file.
+
+    Args:
+        saved_results (list[str]): A list of file paths to the parquet files to be combined.
+    """
+    # create a pyarrow dataset from the list of filenames, then write to a single file
+    dataset = ds.dataset(saved_results, format="parquet")
+    table = dataset.to_table()
+
+    # Write as one parquet file
+    output_path = os.path.join(cfg.OUTPUT_PATH, cfg.OUTPUT_PARQUET_FILENAME)
+
+    pq.write_table(table, output_path)
+
+
 def combine_results(saved_results: Sequence[dict[str, str] | str]):
     """
     Combines various types of result files based on the configuration settings.
@@ -427,6 +541,9 @@ def combine_results(saved_results: Sequence[dict[str, str] | str]):
 
     if "csv" in cfg.RESULT_TYPES:
         combine_csv_files([f["csv"] for f in saved_results if isinstance(f, dict)])
+
+    if "parquet" in cfg.RESULT_TYPES:
+        combine_parquet_files([f["parquet"] for f in saved_results if isinstance(f, dict)])
 
 
 def merge_consecutive_detections(results: dict[str, list], max_consecutive: int | None = None):
@@ -639,6 +756,8 @@ def get_result_file_names(fpath: str):
         result_names["kaleidoscope"] = os.path.join(cfg.OUTPUT_PATH, file_shorthand + ".BirdNET.results.kaleidoscope.csv")
     if "csv" in cfg.RESULT_TYPES:
         result_names["csv"] = os.path.join(cfg.OUTPUT_PATH, file_shorthand + ".BirdNET.results.csv")
+    if "parquet" in cfg.RESULT_TYPES:
+        result_names["parquet"] = os.path.join(cfg.OUTPUT_PATH, file_shorthand + ".BirdNET.results.parquet")
 
     return result_names
 

--- a/birdnet_analyzer/cli.py
+++ b/birdnet_analyzer/cli.py
@@ -353,16 +353,16 @@ def analyzer_parser():
     parser.add_argument(
         "--rtype",
         default={"table"},
-        choices=["table", "audacity", "kaleidoscope", "csv"],
+        choices=["table", "audacity", "kaleidoscope", "csv", "parquet"],
         nargs="+",
-        help="Specifies output format. Values in `['table', 'audacity',  'kaleidoscope', 'csv']`.",
+        help="Specifies output format. Values in `['table', 'audacity',  'kaleidoscope', 'csv', 'parquet']`.",
         action=UniqueSetAction,
     )
     parser.add_argument(
         "--additional_columns",
         choices=POSSIBLE_ADDITIONAL_COLUMNS_MAP.keys(),
         nargs="+",
-        help="Additional columns to include in the output, only applied to the csv output format. "
+        help="Additional columns to include in the output, only applied to the csv and parquet output formats. "
         + f"Values in [{','.join(POSSIBLE_ADDITIONAL_COLUMNS_MAP.keys())}].",
         action=UniqueSetAction,
     )

--- a/birdnet_analyzer/config.py
+++ b/birdnet_analyzer/config.py
@@ -132,6 +132,7 @@ OUTPUT_RAVEN_FILENAME: str = "BirdNET_SelectionTable.txt"  # this is for combine
 # OUTPUT_RTABLE_FILENAME: str = "BirdNET_RTable.csv"
 OUTPUT_KALEIDOSCOPE_FILENAME: str = "BirdNET_Kaleidoscope.csv"
 OUTPUT_CSV_FILENAME: str = "BirdNET_CombinedTable.csv"
+OUTPUT_PARQUET_FILENAME: str = "BirdNET_CombinedTable.parquet"
 
 # File name of the settings csv for batch analysis
 ANALYSIS_PARAMS_FILENAME: str = "BirdNET_analysis_params.csv"

--- a/tests/analyze/test_analyze.py
+++ b/tests/analyze/test_analyze.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 import birdnet_analyzer.config as cfg
@@ -207,12 +208,12 @@ def test_analyze_with_multiple_result_types(mock_analyze_file: MagicMock, mock_s
     mock_analyze_file.return_value = f"{env['test_file1']}_results.txt"
 
     # Call function under test
-    analyze(env["test_file1"], env["output_dir"], rtype=["table", "csv", "audacity"])
+    analyze(env["test_file1"], env["output_dir"], rtype=["table", "csv", "audacity", "parquet"])
 
     # Verify parameter passing
     mock_set_params.assert_called_once()
     _, kwargs = mock_set_params.call_args
-    assert kwargs["rtype"] == ["table", "csv", "audacity"]
+    assert kwargs["rtype"] == ["table", "csv", "audacity", "parquet"]
 
 
 @patch("birdnet_analyzer.analyze.core._set_params")
@@ -430,6 +431,54 @@ def test_analyze_with_speed_up_and_overlap(setup_test_environment, use_perch, au
             actual_end = float(parts[4])
             assert float(actual_start) == expected_start, "Start time does not match expected value"
             assert float(actual_end) == expected_end, "End time does not match expected value"
+
+
+@patch("birdnet_analyzer.utils.ensure_model_exists")
+def test_analyze_with_additional_columns_parquet(mock_ensure_model, setup_test_environment):
+    """Test analyzing with additional columns."""
+    env = setup_test_environment
+
+    soundscape_path = "birdnet_analyzer/example/soundscape.wav"
+
+    assert os.path.exists(soundscape_path), "Soundscape file does not exist"
+
+    # Call function under test
+    analyze(
+        soundscape_path,
+        env["output_dir"],
+        top_n=1,
+        min_conf=0,
+        additional_columns=["lat", "lon", "week", "model", "overlap", "sensitivity", "species_list", "min_conf"],
+        lat=42.5,
+        lon=-76.45,
+        week=20,
+        rtype=["parquet"],
+    )
+
+    mock_ensure_model.assert_called_once()
+    output_file = os.path.join(env["output_dir"], "soundscape.BirdNET.results.parquet")
+    assert os.path.exists(output_file)
+
+    output_df = pd.read_parquet(output_file)
+
+    assert "lat" in output_df.columns, "Latitude column not found in output"
+    assert "lon" in output_df.columns, "Longitude column not found in output"
+    assert "week" in output_df.columns, "Week column not found in output"
+    assert "model" in output_df.columns, "Model column not found in output"
+    assert "overlap" in output_df.columns, "Overlap column not found in output"
+    assert "sensitivity" in output_df.columns, "Sensitivity column not found in output"
+    assert "species_list" in output_df.columns, "Species list column not found in output"
+    assert "min_conf" in output_df.columns, "Min confidence column not found in output"
+
+    for _, row in output_df.iterrows():
+        assert float(row["lat"]) == 42.5, "Latitude value does not match expected value"
+        assert float(row["lon"]) == -76.45, "Longitude value does not match expected value"
+        assert int(row["week"]) == 20, "Week value does not match expected value"
+        assert row["model"] == os.path.basename(cfg.MODEL_PATH), "Model value does not match expected value"
+        assert float(row["overlap"]) == cfg.SIG_OVERLAP, "Overlap value does not match expected value"
+        assert float(row["sensitivity"]) == cfg.SIGMOID_SENSITIVITY, "Sensitivity value does not match expected value"
+        assert row["species_list"] == "", "Species list value does not match expected value"
+        assert float(row["min_conf"]) == 0, "Min confidence value does not match expected value"
 
 
 @patch("birdnet_analyzer.utils.ensure_model_exists")


### PR DESCRIPTION
This PR adds parquet as an output format for analyze. It uses PyArrow to handle all of the parquet reading and writing. 

Currently, it creates a separate "table" for each timestamp, which might result in nonoptimal compression when there are few results per timestamp. There are a few options to improve this:
- Have a buffer that creates a new table for every $n$ rows (slightly more complex implementation, but still not too bad).
- Put all rows in a single table (which might use a lot of memory for large datasets). 

Combining the results into a single file (with `--combine_results`) does make the output much smaller, but it would be ideal to have good compression without having to do this extra step. 

Either way, I have found that parquet's columnar compression works particularly well on classifier outputs due to the repetitive nature of their outputs (e.g. filenames are repeated for many rows). For large datasets, parquet should provide a significant improvement in file size. 

This is somewhat related to #230 as well.

