### PR TITLE
Add Beak Tech urban vs rural monitoring project to projects map

### DIFF
--- a/docs/projects_data.js
+++ b/docs/projects_data.js
@@ -1191,4 +1191,19 @@ var projects_data = [
     "Species Image Credit": "Thünen-Institut",
     "Species Icon": "feather"
   },
+  {
+    "Project name": "Beak Tech: Urban vs Rural Vocal Activity Monitoring",
+    "Organization/Project lead": "Beak Tech",
+    "Target species": "Birds",
+    "Country": "United Kingdom",
+    "Region/Location": "Lake District National Park",
+    "Latitude": 54.311,
+    "Longitude": -2.736,
+    "Contact": "hello@beaktech.org",
+    "Website": "https://beaktech.org",
+    "Paper": "https://beaktech.org/blog/urban-vs-rural-bird-activity",
+    "Species Image": "https://beaktech.org/images/wren.webp",
+    "Species Image Credit": "Sandra Standbridge / Depositphotos",
+    "Species Icon": "feather"
+  },
 ];


### PR DESCRIPTION
Adds a new entry to the projects map for Beak Tech, a UK community interest company running paired BirdNET acoustic monitoring at an urban and a rural site.

We ran two identical BirdNET-Go listening posts: one in the Lake District National Park (urban) and one in rural Wales, for six months, comparing how vocal activity differs between the sites. The data reproduced several known signatures of urbanisation (earlier dawn song, more nocturnal flight calls from migrants, bimodal dawn/dusk peaks), along with one unexpected finding: wrens singing intensely from around 1am at the urban site, well ahead of the robins and blackbirds usually associated with nocturnal urban song.

Write-up: https://beaktech.org/blog/urban-vs-rural-bird-activity

Single entry added to docs/projects_data.js, formatted to match existing entries. Image is self-hosted and licensed.