### PR TITLE
Keep heavy imports off the GUI startup path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,24 @@ that directory is the way to test a first-run experience.
   (`ensure_ascii=False, indent=4, sort_keys=True`). `tests/gui/test_language.py`
   enforces that formatting, key parity across languages, and that each translation
   keeps the `str.format` fields of its `en.json` source.
+- **A GUI setting has three ways to get its value, not one.** Every persisted control
+  (`TabState.persist`) is set (1) at build time from `state.json`, (2) by the user, and
+  (3) programmatically by presets and loaded `*-params.csv` files
+  (`TabState.updates_for`, which sets `value` only). So when one control's state
+  depends on another (the sensitivity slider is disabled for BirdNET 3.0/Perch, the
+  locale dropdown offers only the model's languages, …), cover all three: pass the
+  dependency into the builder for the initial state, handle it in a `.change` handler
+  (which gradio fires for programmatic updates too — `.input` does not), and make the
+  handler also *reset* the dependent value if the loaded one is no longer valid, since
+  the batch update landed before the handler ran. Doing only (2) is the classic gap.
+- **Code comments: only when the code cannot say it.** Default to none. A comment
+  earns its place only for a constraint, a non-obvious *why*, or a measured value
+  that justifies a bound — something a reader could not recover from the code and
+  its names. If the code already explains itself, delete the comment rather than
+  keep it. No history ("once was", "used to fail", "previously") and no narration
+  of what the next line does or how the code was arrived at — that belongs in
+  commit messages and the changelog. The same bar applies to test comments: the
+  test name and its assertions are the explanation.
 - **Don't widen the ruff config to make a fix pass.** The `select`/`ignore` lists in
   `pyproject.toml` are deliberate.
 - **Packaging is an allow-list, not a deny-list.** What ships is decided by the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,9 +97,15 @@ that directory is the way to test a first-run experience.
 
 ## Conventions that are easy to get wrong
 
-- **The GUI test environment has no pywebview.** CI's `gui-tests` extra installs
-  gradio but not pywebview, so any GUI module reachable from a test must not
-  `import webview` at module import time.
+- **The GUI test environment has no pywebview and no plotly.** CI's `gui-tests` extra
+  installs gradio but neither pywebview nor plotly (both are `gui`-only), so no GUI
+  module may import `webview` or `plotly` at module import time — `gui/utils.py`
+  imports `webview` inside the dialog functions and `open_window` only, and its
+  `_WINDOW` annotation is a string under `TYPE_CHECKING`. Keep it that way; the
+  tests import `gui.utils` unstubbed on purpose. A test that builds species-list
+  controls must stub `gu.plot_map_scatter_mapbox` (it draws a plotly map). A local
+  venv with the `gui` extra hides both problems, so before pushing GUI tests run them
+  once with `webview`/`plotly` made unimportable.
 - **Localization is all-or-nothing.** `lang/*.json` holds one file per language
   (currently 10), located via `settings.LANG_DIR`. A new UI string has to be added to
   *every* language file with a real translation — not the English text copied over.

--- a/birdnet_analyzer/gui/search.py
+++ b/birdnet_analyzer/gui/search.py
@@ -104,7 +104,6 @@ def run_search(
 
 
 def build_search_tab() -> gu.TAB_BUILDER_RESULT:
-    from birdnet_analyzer import audio, utils
     from birdnet_analyzer.embeddings.core import SETTINGS_KEY
 
     state = TabState("search")
@@ -275,6 +274,8 @@ def build_search_tab() -> gu.TAB_BUILDER_RESULT:
                         ],
                     )
                     def render_results(results, page, db_path, exports, audio_root):
+                        from birdnet_analyzer import utils
+
                         with gr.Row():
                             if db_path is not None and len(results) > 0:
                                 db = get_search_database(db_path)
@@ -444,6 +445,8 @@ def build_search_tab() -> gu.TAB_BUILDER_RESULT:
 
     def update_query_spectrogram(audiofilepath, db_selection, crop_mode, crop_overlap):
         import numpy as np
+
+        from birdnet_analyzer import audio, utils
 
         if audiofilepath and db_selection:
             db = get_embeddings_database(db_selection)

--- a/birdnet_analyzer/gui/utils.py
+++ b/birdnet_analyzer/gui/utils.py
@@ -11,10 +11,9 @@ import warnings
 from collections.abc import Callable
 from contextlib import contextmanager, suppress
 from html import escape
-from typing import Literal, cast, get_args
+from typing import TYPE_CHECKING, Literal, cast, get_args
 
 import gradio as gr
-import webview
 from birdnet.globals import ACOUSTIC_MODEL_VERSIONS, MODEL_LANGUAGE_EN_US
 
 import birdnet_analyzer.config as cfg
@@ -22,6 +21,9 @@ import birdnet_analyzer.gui.localization as loc
 import birdnet_analyzer.gui.state as gs
 from birdnet_analyzer import settings, utils
 from birdnet_analyzer.gui.state import TabState
+
+if TYPE_CHECKING:
+    import webview
 
 warnings.filterwarnings("ignore")
 loc.load_local_state()
@@ -41,7 +43,7 @@ _BIRDNET_MODEL_VERSIONS: dict[str, str] = {
     _USE_BIRDNET_3_0: "3.0",
 }
 
-_WINDOW: webview.Window | None = None
+_WINDOW: "webview.Window | None" = None
 _URL = ""
 _HEART_LOGO = "data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjE2IiB2aWV3Qm94PSIwIDAgMTYgMTYiIHZlcnNpb249IjEuMSIgd2lkdGg9IjE2IiBkYXRhLXZpZXctY29tcG9uZW50PSJ0cnVlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPg0KICAgIDxwYXRoIGQ9Im04IDE0LjI1LjM0NS42NjZhLjc1Ljc1IDAgMCAxLS42OSAwbC0uMDA4LS4wMDQtLjAxOC0uMDFhNy4xNTIgNy4xNTIgMCAwIDEtLjMxLS4xNyAyMi4wNTUgMjIuMDU1IDAgMCAxLTMuNDM0LTIuNDE0QzIuMDQ1IDEwLjczMSAwIDguMzUgMCA1LjUgMCAyLjgzNiAyLjA4NiAxIDQuMjUgMSA1Ljc5NyAxIDcuMTUzIDEuODAyIDggMy4wMiA4Ljg0NyAxLjgwMiAxMC4yMDMgMSAxMS43NSAxIDEzLjkxNCAxIDE2IDIuODM2IDE2IDUuNWMwIDIuODUtMi4wNDUgNS4yMzEtMy44ODUgNi44MThhMjIuMDY2IDIyLjA2NiAwIDAgMS0zLjc0NCAyLjU4NGwtLjAxOC4wMS0uMDA2LjAwM2gtLjAwMlpNNC4yNSAyLjVjLTEuMzM2IDAtMi43NSAxLjE2NC0yLjc1IDMgMCAyLjE1IDEuNTggNC4xNDQgMy4zNjUgNS42ODJBMjAuNTggMjAuNTggMCAwIDAgOCAxMy4zOTNhMjAuNTggMjAuNTggMCAwIDAgMy4xMzUtMi4yMTFDMTIuOTIgOS42NDQgMTQuNSA3LjY1IDE0LjUgNS41YzAtMS44MzYtMS40MTQtMy0yLjc1LTMtMS4zNzMgMC0yLjYwOS45ODYtMy4wMjkgMi40NTZhLjc0OS43NDkgMCAwIDEtMS40NDIgMEM2Ljg1OSAzLjQ4NiA1LjYyMyAyLjUgNC4yNSAyLjVaIj48L3BhdGg+DQo8L3N2Zz4="  # noqa: E501
 _SAMPLE_KEYS = Literal[
@@ -291,6 +293,8 @@ def select_folder(state_key=None):
     Returns:
         str: The path of the selected folder, or None if no folder was selected.
     """
+    import webview
+
     if sys.platform == "win32":
         from tkinter import Tk, filedialog
 
@@ -1101,6 +1105,8 @@ def save_file_dialog(filetypes=(), state_key=None, default_filename=""):
     Returns:
         The selected file or None of the dialog was canceled.
     """
+    import webview
+
     assert _WINDOW is not None
 
     initial_selection = settings.get_state(state_key, "") if state_key else ""
@@ -1131,6 +1137,8 @@ def select_file(filetypes=(), state_key=None):
     Returns:
         The selected file or None of the dialog was canceled.
     """
+    import webview
+
     assert _WINDOW is not None
 
     initial_selection = settings.get_state(state_key, "") if state_key else ""
@@ -1405,6 +1413,7 @@ def species_lists(
 
 
 def download_plot(plot, filename=""):
+    import webview
     from PIL import Image
 
     res: str = _WINDOW.create_file_dialog(  # type: ignore
@@ -1595,6 +1604,8 @@ def open_window(
         builder (list[Callable] | Callable): A callable or a list of callables that
         build the GUI components.
     """
+    import webview
+
     global _URL
     multiprocessing.freeze_support()
 

--- a/birdnet_analyzer/gui/utils.py
+++ b/birdnet_analyzer/gui/utils.py
@@ -1023,8 +1023,9 @@ def species_list_coordinates(state: TabState, show_map=False):
                 info=loc.localize("species-list-coordinates-lon-number-info"),
             )
 
+        # No initial figure: open_window's demo.load repopulates every map plot on
+        # page load, so building one here only slows startup.
         map_plot = gr.Plot(
-            plot_map_scatter_mapbox(lat_number.value, lon_number.value),
             show_label=False,
             scale=2,
             visible=show_map,

--- a/tests/gui/test_download_progress.py
+++ b/tests/gui/test_download_progress.py
@@ -1,13 +1,8 @@
 """The GUI shows the birdnet library's model downloads."""
 
-import sys
-from unittest.mock import MagicMock
-
 import pytest
 
 gr = pytest.importorskip("gradio")
-
-sys.modules.setdefault("webview", MagicMock(settings={}))
 
 
 def test_download_progress_routes_library_updates_to_gradio(monkeypatch):

--- a/tests/gui/test_sensitivity_slider.py
+++ b/tests/gui/test_sensitivity_slider.py
@@ -5,14 +5,9 @@ Perch disables the slider and shows 1.0 (what the analysis will use); switching 
 restores the value the user last set.
 """
 
-import sys
-from unittest.mock import MagicMock
-
 import pytest
 
 gr = pytest.importorskip("gradio")
-
-sys.modules.setdefault("webview", MagicMock(settings={}))
 
 from birdnet_analyzer import settings  # noqa: E402
 from birdnet_analyzer.gui import state as gs  # noqa: E402

--- a/tests/gui/test_startup_imports.py
+++ b/tests/gui/test_startup_imports.py
@@ -33,14 +33,6 @@ FORBIDDEN_AFTER_BUILD = [m for m in FORBIDDEN_ON_IMPORT if m != "matplotlib"]
 PROBE = f"""
 import json
 import sys
-from unittest.mock import MagicMock
-
-# The gui-tests environment has no pywebview.
-stub = MagicMock()
-stub.settings = {{}}
-sys.modules["webview"] = stub
-sys.modules["webview.platforms"] = MagicMock()
-sys.modules["webview.platforms.winforms"] = MagicMock()
 
 import birdnet_analyzer.gui.multi_file as mfa
 import birdnet_analyzer.gui.segments as gseg

--- a/tests/gui/test_startup_imports.py
+++ b/tests/gui/test_startup_imports.py
@@ -1,0 +1,97 @@
+"""Guard the GUI startup path against heavy imports creeping back in.
+
+Startup cost is dominated by what gets imported before the window opens. The
+expensive libraries (tensorflow, scipy/librosa via ``birdnet_analyzer.audio``,
+plotly, sklearn) are all deferred into event handlers; these tests fail if any
+of them sneaks back onto the import or Blocks-build path.
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("gradio")
+
+# Never allowed while importing the tab modules.
+FORBIDDEN_ON_IMPORT = [
+    "tensorflow",
+    "keras",
+    "scipy",
+    "librosa",
+    "plotly",
+    "sklearn",
+    "matplotlib",
+]
+
+# Never allowed after building all tabs. matplotlib is exempt here: gradio's
+# dataframe components import pandas' Styler (which imports matplotlib) during
+# the build, which is outside our control.
+FORBIDDEN_AFTER_BUILD = [m for m in FORBIDDEN_ON_IMPORT if m != "matplotlib"]
+
+PROBE = f"""
+import json
+import sys
+from unittest.mock import MagicMock
+
+# The gui-tests environment has no pywebview.
+stub = MagicMock()
+stub.settings = {{}}
+sys.modules["webview"] = stub
+sys.modules["webview.platforms"] = MagicMock()
+sys.modules["webview.platforms.winforms"] = MagicMock()
+
+import birdnet_analyzer.gui.multi_file as mfa
+import birdnet_analyzer.gui.segments as gseg
+import birdnet_analyzer.gui.single_file as sfa
+import birdnet_analyzer.gui.utils as gu
+from birdnet_analyzer.gui import (
+    embeddings,
+    evaluation,
+    review,
+    search,
+    species,
+    train,
+)
+
+on_import = [m for m in {FORBIDDEN_ON_IMPORT!r} if m in sys.modules]
+
+import gradio as gr
+
+with gr.Blocks():
+    sfa.build_single_analysis_tab()
+    mfa.build_multi_analysis_tab()
+    train.build_train_tab()
+    gseg.build_segments_tab()
+    review.build_review_tab()
+    species.build_species_tab()
+    embeddings.build_embeddings_tab()
+    search.build_search_tab()
+    evaluation.build_evaluation_tab()
+
+after_build = [m for m in {FORBIDDEN_AFTER_BUILD!r} if m in sys.modules]
+
+print(json.dumps({{"on_import": on_import, "after_build": after_build}}))
+"""
+
+
+def test_startup_path_stays_free_of_heavy_imports():
+    result = subprocess.run(
+        [sys.executable, "-c", PROBE],
+        capture_output=True,
+        text=True,
+        timeout=110,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    loaded = json.loads(result.stdout.splitlines()[-1])
+
+    assert loaded["on_import"] == [], (
+        f"Heavy modules imported by the tab modules: {loaded['on_import']}. "
+        "Defer these imports into the event handlers that use them."
+    )
+    assert loaded["after_build"] == [], (
+        f"Heavy modules imported while building the tabs: {loaded['after_build']}. "
+        "Defer these imports into the event handlers that use them."
+    )


### PR DESCRIPTION
## Summary

- **Startup**: the search tab imported `birdnet_analyzer.audio` (scipy.signal, librosa) while building, and every species-list coordinates block rendered a plotly map figure that `open_window`'s `demo.load` regenerates on page load anyway. Both are now lazy. GUI startup to server-up drops from ~6.2 s to ~4.5 s locally.
- **Regression guard**: `tests/gui/test_startup_imports.py` imports all tab modules and builds the full Blocks in a subprocess, asserting tensorflow, scipy, librosa, plotly and sklearn stay unloaded.
- **`gui.utils` importable without pywebview**: the `webview` import moves into the dialog functions and `open_window`; the `_WINDOW` annotation is a string under `TYPE_CHECKING`. The `sys.modules["webview"]` stubs in the tests are removed so CI exercises this. (Raised by Copilot on #984; deferred there as out of scope.)
- **AGENTS.md**: three conventions — the three ways a persisted GUI control gets its value (build / user / preset-or-params load), the code-comment policy (default to none; only constraints, non-obvious whys, measured values), and the pywebview/plotly-free test environment.

## Verification

- All `tests/gui` pass with `webview` and `plotly` made unimportable (CI's `gui-tests` condition), no stubs.
- Startup regression test verified to fail against a tree with the eager imports restored.

_This PR was originally the combined "General cleanup" draft; the frozen-CLI, sensitivity and download-progress parts landed separately as #982, #983 and #984._

🤖 Generated with [Claude Code](https://claude.com/claude-code)