### PR TITLE
Frozen console CLI: stop diverting its output to logs.txt

### DIFF
--- a/birdnet_analyzer/settings.py
+++ b/birdnet_analyzer/settings.py
@@ -126,7 +126,25 @@ class _RotatingLogFile(io.TextIOBase):
         return self._file.encoding
 
 
-if FROZEN:
+def _divert_output_to_log() -> bool:
+    """Whether a frozen build should send stdout/stderr to logs.txt.
+
+    Only the windowed GUI build has nowhere readable to print; the console CLI
+    executable must keep printing to its terminal or pipe. Decided by build shape:
+    a windowed PyInstaller build on Windows has ``sys.stdout is None``, and on macOS
+    the only frozen artifact is the windowed .app. Don't probe the descriptors
+    instead: on Windows a console handle is indistinguishable from NUL by fstat.
+    """
+    if not FROZEN:
+        return False
+
+    if sys.platform == "darwin":
+        return True
+
+    return sys.stdout is None or sys.stderr is None
+
+
+if _divert_output_to_log():
     # divert stdout & stderr to logs.txt file since we have no console when deployed
     _ensure_appdir_exists()
     sys.stderr = sys.stdout = _RotatingLogFile(Path(LOG_FILE), MAX_LOG_SIZE)

--- a/tests/gui/test_settings.py
+++ b/tests/gui/test_settings.py
@@ -35,3 +35,31 @@ def test_gui_runtime_files_use_user_appdir_when_not_frozen(monkeypatch, tmp_path
         assert (expected_appdir / "error_log.txt").exists()
     finally:
         logs._remove_installed_handlers()
+
+
+def test_frozen_output_diverted_only_for_windowed_builds(monkeypatch):
+    # Frozen builds divert stdout/stderr into logs.txt only when nobody can read them.
+    # The console CLI executable (real stream, whether terminal, pipe or file) must
+    # keep printing; the windowed GUI must be diverted. On Windows a windowed
+    # PyInstaller build has sys.stdout None; on macOS the only frozen artifact is the
+    # windowed .app.
+    from unittest.mock import MagicMock
+
+    monkeypatch.setattr(settings, "FROZEN", False)
+    assert not settings._divert_output_to_log()
+
+    monkeypatch.setattr(settings, "FROZEN", True)
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    monkeypatch.setattr(sys, "stdout", MagicMock())
+    monkeypatch.setattr(sys, "stderr", MagicMock())
+    assert not settings._divert_output_to_log(), "console exe must keep printing"
+
+    monkeypatch.setattr(sys, "stdout", None)
+    monkeypatch.setattr(sys, "stderr", None)
+    assert settings._divert_output_to_log(), "windowed exe must be diverted"
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(sys, "stdout", MagicMock())
+    monkeypatch.setattr(sys, "stderr", MagicMock())
+    assert settings._divert_output_to_log(), "the mac .app is always windowed"


### PR DESCRIPTION
Every frozen process sent stdout/stderr to logs.txt, so the console CLI executable printed nothing to its terminal. Divert only for the windowed GUI: on Windows a windowed PyInstaller build has sys.stdout None; on macOS the only frozen artifact is the windowed .app. Deliberately not inferred from the descriptors - on Windows a console handle is indistinguishable from NUL by fstat.