### PR TITLE
Track birdnet main: sensitivity only for 2.4-based models

### DIFF
--- a/birdnet_analyzer/analyze/core.py
+++ b/birdnet_analyzer/analyze/core.py
@@ -115,8 +115,16 @@ def analyze(
     """
     import birdnet_analyzer.config as cfg
     from birdnet_analyzer.analyze.resume import ResumeJournal, RunMetadata
-    from birdnet_analyzer.model_utils import run_geomodel, run_inference
+    from birdnet_analyzer.model_utils import (
+        effective_sensitivity,
+        run_geomodel,
+        run_inference,
+    )
     from birdnet_analyzer.utils import save_params_file
+
+    # Settle the sensitivity here so the params file, result columns and the resume
+    # fingerprint all record the value the analysis actually used.
+    sensitivity = effective_sensitivity(sensitivity, model, birdnet, classifier)
 
     species_list_file = slist if isinstance(slist, (str, Path)) else ""
     rtypes: list[RESULT_TYPES] = [rtype] if isinstance(rtype, str) else rtype

--- a/birdnet_analyzer/cli.py
+++ b/birdnet_analyzer/cli.py
@@ -290,7 +290,7 @@ def sigmoid_args():
         "--sensitivity",
         type=lambda a: min(1.5, max(0.5, float(a))),
         default=1.0,
-        help="Detection sensitivity; Higher values result in higher sensitivity. Values in [0.5, 1.5]. Values other than 1.0 will shift the sigmoid functionon the x-axis. Use complementary to the cut-off threshold.",
+        help="Detection sensitivity; Higher values result in higher sensitivity. Values in [0.5, 1.5]. Values other than 1.0 will shift the sigmoid function on the x-axis. Use complementary to the cut-off threshold. Only applies to BirdNET 2.4 and custom classifiers; ignored for BirdNET 3.0 (which applies the sigmoid inside the model) and Perch.",
     )
 
     return p

--- a/birdnet_analyzer/gui/utils.py
+++ b/birdnet_analyzer/gui/utils.py
@@ -90,6 +90,19 @@ def birdnet_version(model_choice: str) -> str:
     return _BIRDNET_MODEL_VERSIONS.get(model_choice, "2.4")
 
 
+def model_supports_sensitivity(model_choice: str) -> bool:
+    """Whether the sensitivity slider applies to the selected model choice."""
+    from birdnet_analyzer.model_utils import supports_sensitivity
+
+    if model_choice == _CUSTOM_CLASSIFIER:
+        return True
+
+    if model_choice == _USE_PERCH:
+        return False
+
+    return supports_sensitivity("birdnet", birdnet_version(model_choice))
+
+
 def model_languages(model_choice: str) -> list[str]:
     """The label languages the given model's version supports, sorted.
 
@@ -598,12 +611,17 @@ def default_model():
 def sample_species_model_settings(state: TabState, opened=True):
     # The model decides which sample and species settings are available, so it has to
     # be known before those are built, even though it is shown below them.
-    is_perch = (
-        state.get("model_selection_radio", default_model(), choices=model_choices())
-        == _USE_PERCH
+    model_choice = state.get(
+        "model_selection_radio", default_model(), choices=model_choices()
     )
+    is_perch = model_choice == _USE_PERCH
 
-    sample_settings = sample_sliders(state, opened=opened, is_perch=is_perch)
+    sample_settings = sample_sliders(
+        state,
+        opened=opened,
+        is_perch=is_perch,
+        sensitivity_enabled=model_supports_sensitivity(model_choice),
+    )
     species_settings = species_lists(state, opened=opened, is_perch=is_perch)
     model_settings = model_selection(state, opened=opened)
 
@@ -615,8 +633,16 @@ def sample_species_model_settings(state: TabState, opened=True):
             else [_CUSTOM_SPECIES, _PREDICT_SPECIES, _ALL_SPECIES]
         )
 
+        # A disabled slider shows 1.0 so it never displays a value the analysis will
+        # not use (e.g. one carried over from a 2.4 preset).
+        sensitivity_update = (
+            gr.update(interactive=True)
+            if model_supports_sensitivity(value)
+            else gr.update(interactive=False, value=1.0)
+        )
+
         return (
-            gr.update(interactive=not is_perch),
+            sensitivity_update,
             gr.update(maximum=4.9 if is_perch else 2.9),
             # Keep the current species selection (e.g. the one a preset was just
             # applied with) as long as the new model offers it.
@@ -688,7 +714,7 @@ def sample_species_model_settings(state: TabState, opened=True):
 
 
 def sample_sliders(
-    state: TabState, opened=True, is_perch=False
+    state: TabState, opened=True, is_perch=False, sensitivity_enabled=True
 ) -> dict[_SAMPLE_KEYS, gr.components.Component]:
     """Creates the gradio accordion for sample settings.
 
@@ -696,6 +722,7 @@ def sample_sliders(
         state: The persisted settings of the tab the accordion belongs to.
         opened: If True the accordion is open on init.
         is_perch: If True the settings are limited to what the Perch model supports.
+        sensitivity_enabled: Whether the selected model supports a sensitivity.
     Returns:
         A dict with the created elements.
     """
@@ -753,10 +780,14 @@ def sample_sliders(
                     maximum=1.5,
                     value=1.0,
                     step=0.01,
-                    interactive=not is_perch,
+                    interactive=sensitivity_enabled,
                     label=loc.localize("inference-settings-sensitivity-slider-label"),
                     info=loc.localize("inference-settings-sensitivity-slider-info"),
                 )
+                # Show what the analysis will use: a value persisted from a 2.4 run
+                # would otherwise sit visibly on the disabled slider.
+                if not sensitivity_enabled:
+                    sensitivity_slider.value = 1.0
                 overlap_slider = state.persist(
                     "overlap_slider",
                     gr.Slider,

--- a/birdnet_analyzer/gui/utils.py
+++ b/birdnet_analyzer/gui/utils.py
@@ -634,12 +634,18 @@ def sample_species_model_settings(state: TabState, opened=True):
         )
 
         # A disabled slider shows 1.0 so it never displays a value the analysis will
-        # not use (e.g. one carried over from a 2.4 preset).
-        sensitivity_update = (
-            gr.update(interactive=True)
-            if model_supports_sensitivity(value)
-            else gr.update(interactive=False, value=1.0)
-        )
+        # not use; re-enabling brings back the value the user last set (persisted
+        # on release, so read live rather than from the state snapshot).
+        if model_supports_sensitivity(value):
+            persisted = settings.get_tab_settings(state.tab).get("sensitivity_slider")
+            restored = (
+                min(1.5, max(0.5, float(persisted)))
+                if isinstance(persisted, (int, float))
+                else 1.0
+            )
+            sensitivity_update = gr.update(interactive=True, value=restored)
+        else:
+            sensitivity_update = gr.update(interactive=False, value=1.0)
 
         return (
             sensitivity_update,

--- a/birdnet_analyzer/model_utils.py
+++ b/birdnet_analyzer/model_utils.py
@@ -309,6 +309,41 @@ def _language_for_version(language: MODEL_LANGUAGES, version: str) -> MODEL_LANG
     return MODEL_LANGUAGE_EN_US
 
 
+def supports_sensitivity(
+    model: str, version: str = "3.0", classifier: str | None = None
+) -> bool:
+    """Whether the selected model takes a scaled (sensitivity) sigmoid.
+
+    BirdNET 2.4 and custom classifiers (which run on the 2.4 base) do. BirdNET 3.0
+    applies the sigmoid inside the model graph, and the birdnet library rejects a
+    sensitivity other than 1.0 for it. Perch outputs raw logits and is run without a
+    sigmoid here (its scores are not probabilities), so sensitivity does not apply.
+    Newer BirdNET versions are assumed to behave like 3.0 until known otherwise.
+    """
+    if classifier:
+        return True
+
+    return model == "birdnet" and version == "2.4"
+
+
+def effective_sensitivity(
+    sensitivity: float, model: str, version: str = "3.0", classifier: str | None = None
+) -> float:
+    """The sensitivity the analysis will use; warns if the requested one is dropped."""
+    if supports_sensitivity(model, version, classifier):
+        return sensitivity
+
+    if sensitivity != 1.0:
+        logger.warning(
+            "Sensitivity %s ignored: it only applies to BirdNET 2.4 and custom "
+            "classifiers, not to %s.",
+            sensitivity,
+            "Perch" if model == "perch" else f"BirdNET {version}",
+        )
+
+    return 1.0
+
+
 def run_inference(
     path,
     model="birdnet",
@@ -377,6 +412,10 @@ def run_inference(
     from birdnet.acoustic.inference.configs import InferenceConfig
 
     input_files = InferenceConfig.validate_input_files(path)
+
+    sigmoid_sensitivity = effective_sensitivity(
+        sigmoid_sensitivity, model, version, classifier
+    )
 
     with acoustic_model.predict_session(
         top_k=top_k,

--- a/docs/breaking-changes.rst
+++ b/docs/breaking-changes.rst
@@ -108,6 +108,22 @@ you need one of its dropped languages. In the GUI the locale dropdown offers onl
 selected model's languages.
 
 
+Sensitivity has no effect on BirdNET 3.0
+----------------------------------------
+
+**What changed.** The 3.0 model applies its sigmoid inside the model graph and
+outputs probabilities directly, so the sigmoid cannot be rescaled. ``--sensitivity``
+therefore only applies to BirdNET 2.4 and custom classifiers (which run on the 2.4
+base); Perch never used it.
+
+**Consequence.** With the default 3.0 model a ``--sensitivity`` other than ``1.0`` is
+ignored, with a warning. In the GUI the sensitivity slider is disabled while 3.0 or
+Perch is selected.
+
+**What to do.** Use ``--min_conf`` to tune 3.0 detections. If you rely on
+sensitivity, select the 2.4 model (``--birdnet 2.4``).
+
+
 Custom classifiers and training stay on the 2.4 base
 ----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,10 @@ dependencies = [
     "tqdm",
     "pandas",
     "matplotlib",
-    "birdnet==1.0.0",
+    # Direct URL: unreleased birdnet main (3.0 sigmoid fix, pb backend fix, download
+    # progress hook). PyPI rejects direct-URL requirements, so this must become a
+    # version pin before publishing.
+    "birdnet @ https://github.com/birdnet-team/birdnet/archive/75394998.tar.gz",
 ]
 
 [project.optional-dependencies]

--- a/tests/gui/test_sensitivity_slider.py
+++ b/tests/gui/test_sensitivity_slider.py
@@ -20,6 +20,13 @@ from birdnet_analyzer.gui import state as gs  # noqa: E402
 from birdnet_analyzer.gui import utils as gu  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def no_map_figure(monkeypatch):
+    # The species-list block draws a plotly map while building; plotly is a gui-only
+    # extra and the map is irrelevant here.
+    monkeypatch.setattr(gu, "plot_map_scatter_mapbox", lambda *a, **k: None)
+
+
 @pytest.fixture
 def appdir(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "APPDIR", tmp_path)

--- a/tests/gui/test_sensitivity_slider.py
+++ b/tests/gui/test_sensitivity_slider.py
@@ -1,0 +1,78 @@
+"""The sensitivity slider follows the selected model.
+
+Only BirdNET 2.4 and custom classifiers take a sensitivity. Selecting BirdNET 3.0 or
+Perch disables the slider and shows 1.0 (what the analysis will use); switching back
+restores the value the user last set.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+gr = pytest.importorskip("gradio")
+
+# gui.utils imports pywebview at module level, which the gui-tests extra lacks.
+sys.modules.setdefault("webview", MagicMock(settings={}))
+
+from birdnet_analyzer import settings  # noqa: E402
+from birdnet_analyzer.gui import state as gs  # noqa: E402
+from birdnet_analyzer.gui import utils as gu  # noqa: E402
+
+
+@pytest.fixture
+def appdir(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "APPDIR", tmp_path)
+    monkeypatch.setattr(settings, "STATE_SETTINGS_PATH", str(tmp_path / "state.json"))
+    monkeypatch.setattr(settings, "ERROR_LOG_FILE", str(tmp_path / "error_log.txt"))
+    monkeypatch.setattr(gs, "_PERSISTED", [])
+    return tmp_path
+
+
+def build():
+    with gr.Blocks() as demo:
+        sample, _, model = gu.sample_species_model_settings(gs.TabState("multi"))
+    radio = model["model_selection_radio"]
+    slider = sample["sensitivity_slider"]
+    # The radio has several change handlers; the one that drives the slider is the one
+    # listing it among its outputs.
+    handler = next(
+        event.fn
+        for event in demo.fns.values()
+        if event.targets
+        and event.targets[0] == (radio._id, "change")
+        and slider in event.outputs
+    )
+    return slider, handler
+
+
+def test_slider_disabled_for_3_0_and_restored_for_2_4(appdir):
+    # The user set 1.25 while on 2.4 (persisted on slider release).
+    settings.set_tab_setting("multi", "sensitivity_slider", 1.25)
+    settings.set_tab_setting("multi", "model_selection_radio", gu._USE_BIRDNET_2_4)
+
+    slider, on_model_change = build()
+    assert slider.interactive
+    assert slider.value == 1.25
+
+    to_3_0, *_ = on_model_change(gu._USE_BIRDNET_3_0, gu._ALL_SPECIES)
+    assert to_3_0["interactive"] is False
+    assert to_3_0["value"] == 1.0
+
+    back_to_2_4, *_ = on_model_change(gu._USE_BIRDNET_2_4, gu._ALL_SPECIES)
+    assert back_to_2_4["interactive"] is True
+    assert back_to_2_4["value"] == 1.25, "the user's sensitivity comes back"
+
+    to_perch, *_ = on_model_change(gu._USE_PERCH, gu._ALL_SPECIES)
+    assert to_perch["interactive"] is False
+    assert to_perch["value"] == 1.0
+
+
+def test_slider_built_disabled_at_1_0_when_3_0_is_persisted(appdir):
+    # A 1.25 persisted from a 2.4 session must not sit visibly on the disabled slider.
+    settings.set_tab_setting("multi", "sensitivity_slider", 1.25)
+    settings.set_tab_setting("multi", "model_selection_radio", gu._USE_BIRDNET_3_0)
+
+    slider, _ = build()
+    assert not slider.interactive
+    assert slider.value == 1.0

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -62,3 +62,46 @@ def test_language_for_version_keeps_supported_and_falls_back_otherwise():
     assert model_utils._language_for_version(only_v24[0], "3.0") == MODEL_LANGUAGE_EN_US
     assert model_utils._language_for_version(only_v30[0], "3.0") == only_v30[0]
     assert model_utils._language_for_version(only_v30[0], "2.4") == MODEL_LANGUAGE_EN_US
+
+
+def test_supports_sensitivity_only_for_2_4_based_models():
+    # Sensitivity scales the sigmoid the analyzer applies to logits: BirdNET 2.4 and
+    # custom classifiers (2.4 base). BirdNET 3.0 applies its sigmoid inside the model
+    # (the library raises for a sensitivity other than 1.0); Perch is run on raw logits
+    # without a sigmoid. Unknown future versions are treated like 3.0.
+    assert model_utils.supports_sensitivity("birdnet", "2.4")
+    assert not model_utils.supports_sensitivity("birdnet", "3.1")
+    assert model_utils.supports_sensitivity("birdnet", "3.0", classifier="cc.tflite")
+    assert not model_utils.supports_sensitivity("birdnet", "3.0")
+    assert not model_utils.supports_sensitivity("perch")
+
+
+def test_run_inference_drops_sensitivity_for_3_0(monkeypatch, tmp_path):
+    # A non-default sensitivity is coerced to 1.0 before it reaches the library, which
+    # would otherwise reject it for 3.0 and crash the analysis (GUI state can carry the
+    # slider value over from a 2.4 run).
+    from contextlib import contextmanager
+    from unittest.mock import MagicMock
+
+    seen = {}
+
+    @contextmanager
+    def fake_predict_session(**kwargs):
+        seen.update(kwargs)
+        session = MagicMock()
+        session.run.return_value = "result"
+        yield session
+
+    fake_model = MagicMock()
+    fake_model.predict_session = fake_predict_session
+    monkeypatch.setattr(model_utils.birdnet, "load", lambda *a, **k: fake_model)
+
+    audio = tmp_path / "a.wav"
+    audio.write_bytes(b"")
+
+    result = model_utils.run_inference(
+        str(audio), model="birdnet", version="3.0", sigmoid_sensitivity=1.25
+    )
+
+    assert result == "result"
+    assert seen["sigmoid_sensitivity"] == 1.0


### PR DESCRIPTION
birdnet 1.0.0 applied a second sigmoid to the 3.0 acoustic model (all confidences squashed into [0.5, 0.73], every species passing any threshold) and its 3.0 pb backend failed every inference. Both are fixed on birdnet main, which the dependency now points at as a direct URL; PyPI rejects direct-URL requirements, so it must become a version pin before publishing.

With the fix, the library rejects a sigmoid_sensitivity other than 1.0 for 3.0 (the exports apply the sigmoid in-graph). Sensitivity is settled once in analyze() via model_utils.effective_sensitivity: only BirdNET 2.4 and custom classifiers take it, 3.0/Perch runs coerce to 1.0 with a warning, so the params file, result columns and resume fingerprint record the value actually used. The GUI slider is disabled (and shown as 1.0) whenever 3.0 or Perch is selected, at build, on switch and on preset load. Documented in the breaking-changes page and the CLI help.