### PR TITLE
Pin birdnet 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "keras",
     # ONNX runtime backs 3.0 acoustic + geo inference: no TensorFlow load, faster.
     # TensorFlow above is still required for training and the 2.4/perch/custom paths.
-    # >=1.16 is birdnet's own floor for its [onnx] extra.
     "onnxruntime>=1.16.0",
     "numpy",
     "scipy",
@@ -49,10 +48,7 @@ dependencies = [
     "tqdm",
     "pandas",
     "matplotlib",
-    # Direct URL: unreleased birdnet main (3.0 sigmoid fix, pb backend fix, download
-    # progress hook). PyPI rejects direct-URL requirements, so this must become a
-    # version pin before publishing.
-    "birdnet @ https://github.com/birdnet-team/birdnet/archive/75394998.tar.gz",
+    "birdnet==1.1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Replaces the direct-URL birdnet requirement with the released `birdnet==1.1.0` from PyPI — this was the release gate, since PyPI rejects direct-URL dependencies.

The release contains everything the URL pin pointed at (3.0 double-sigmoid fix, 3.0 pb backend fix, download progress callback) plus: TensorFlow is now optional for birdnet itself (base install runs 3.0 on onnxruntime and 2.4 via LiteRT), checksum-verified per-release label caches, and the abandoned-lock reclaim. The analyzer still declares its own TensorFlow dependency for training and the 2.4/perch/custom paths, so nothing changes for analyzer installs yet.

Note from the release: **3.0 confidence values change relative to birdnet 1.0.0** (the double-sigmoid fix) — thresholds tuned against 1.0.0-era 3.0 output need revisiting.

## Verification

Full test suite against the PyPI wheel: 624 passed, 1 skipped. `pip check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)